### PR TITLE
Fix Leveled Menu Bar Element Alignment

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1452,26 +1452,26 @@ void DrawLeveledMenu() {
         if (ImGui::BeginMenu("Floating Numbers")) {
             EnhancementCheckbox("Enemy Damage", "gLeveledFloatingNumberEnemyDamage", false, "",
                                 UIWidgets::CheckboxGraphics::Checkmark, true);
-            EnhancementCheckbox("Player Damage", "gLeveledFloatingNumberPlayerDamage", false, "",
+            PaddedEnhancementCheckbox("Player Damage", "gLeveledFloatingNumberPlayerDamage", true, false, false, "",
                                 UIWidgets::CheckboxGraphics::Checkmark, true);
-            EnhancementCheckbox("EXP Gain", "gLeveledFloatingNumberExpGain", false, "",
+            PaddedEnhancementCheckbox("EXP Gain", "gLeveledFloatingNumberExpGain", true, false, false, "",
                                 UIWidgets::CheckboxGraphics::Checkmark, true);
             ImGui::EndMenu();
         }
 
-        EnhancementCheckbox("Level Gives Bonus Hearts", "gLeveledHeartsWithLevelUp", false, "",
+        PaddedEnhancementCheckbox("Level Gives Bonus Hearts", "gLeveledHeartsWithLevelUp", true, false, false, "",
                             UIWidgets::CheckboxGraphics::Checkmark, true);
-        EnhancementCheckbox("Level Affects Magic Capacity", "gLeveledMagicWithLevelUp", false, "",
+        PaddedEnhancementCheckbox("Level Affects Magic Capacity", "gLeveledMagicWithLevelUp", true, false, false, "",
                             UIWidgets::CheckboxGraphics::Checkmark, true);
-        EnhancementCheckbox("Enemy Level Affects Base Attack", "gLeveledEnemyAttackScalesWithLevel",
+        PaddedEnhancementCheckbox("Enemy Level Affects Base Attack", "gLeveledEnemyAttackScalesWithLevel", true, false,
                             false, "", UIWidgets::CheckboxGraphics::Checkmark, true);
         UIWidgets::Tooltip("Enemies have a fixed attack value. This option scales this up the higher the enemy's "
                             "Power(Strength) stat. \nThis will increase difficulty a bit.");
-        EnhancementCheckbox("Equipment Affects Stats", "gLeveledEquipmentStats", false, "",
+        PaddedEnhancementCheckbox("Equipment Affects Stats", "gLeveledEquipmentStats", true, false, false, "",
                             UIWidgets::CheckboxGraphics::Checkmark, true);
-        EnhancementCheckbox("Navi tells enemy level", "gLeveledNaviLevel", false, "",
+        PaddedEnhancementCheckbox("Navi tells enemy level", "gLeveledNaviLevel", true, false, false, "",
                             UIWidgets::CheckboxGraphics::Checkmark, true);
-        EnhancementCheckbox("Navi tells enemy max HP", "gLeveledNaviMaxHP", false, "",
+        PaddedEnhancementCheckbox("Navi tells enemy max HP", "gLeveledNaviMaxHP", true, true, false, "",
                             UIWidgets::CheckboxGraphics::Checkmark, true);
 
         if (ImGui::BeginMenu("Heart Capacity in Units")) {
@@ -1490,7 +1490,7 @@ void DrawLeveledMenu() {
             UIWidgets::EnhancementRadioButton("48", "gLeveledHeartUnits", 12);
             ImGui::EndMenu();
         }
-        UIWidgets::Tooltip("Sets how much health units a heart is worth.");
+        UIWidgets::Tooltip("Sets how many health units a heart is worth.");
 
         // if (ImGui::Button("Add 2000 EXP")){
         //     gSaveContext.experience += 2000;

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1474,7 +1474,7 @@ void DrawLeveledMenu() {
         PaddedEnhancementCheckbox("Navi tells enemy max HP", "gLeveledNaviMaxHP", true, true, false, "",
                             UIWidgets::CheckboxGraphics::Checkmark, true);
 
-        if (ImGui::BeginMenu("Heart Capacity in Units")) {
+        if (ImGui::BeginMenu("Heart Container Value in Units")) {
             CVarGetInteger("gLeveledHeartUnits", 4);
             UIWidgets::EnhancementRadioButton("4", "gLeveledHeartUnits", 1);
             UIWidgets::EnhancementRadioButton("8", "gLeveledHeartUnits", 2);
@@ -1490,7 +1490,7 @@ void DrawLeveledMenu() {
             UIWidgets::EnhancementRadioButton("48", "gLeveledHeartUnits", 12);
             ImGui::EndMenu();
         }
-        UIWidgets::Tooltip("Sets how many health units a heart is worth.");
+        UIWidgets::Tooltip("Sets how many health units each completed heart container is worth.\nOne heart on the health meter is equal to 16 health units.\nA lower setting results in lower total health.");
 
         // if (ImGui::Button("Add 2000 EXP")){
         //     gSaveContext.experience += 2000;

--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -1447,6 +1447,59 @@ void DrawRandomizerMenu() {
     }
 }
 
+void DrawLeveledMenu() {
+    if (ImGui::BeginMenu("Leveled")) {
+        if (ImGui::BeginMenu("Floating Numbers")) {
+            EnhancementCheckbox("Enemy Damage", "gLeveledFloatingNumberEnemyDamage", false, "",
+                                UIWidgets::CheckboxGraphics::Checkmark, true);
+            EnhancementCheckbox("Player Damage", "gLeveledFloatingNumberPlayerDamage", false, "",
+                                UIWidgets::CheckboxGraphics::Checkmark, true);
+            EnhancementCheckbox("EXP Gain", "gLeveledFloatingNumberExpGain", false, "",
+                                UIWidgets::CheckboxGraphics::Checkmark, true);
+            ImGui::EndMenu();
+        }
+
+        EnhancementCheckbox("Level Gives Bonus Hearts", "gLeveledHeartsWithLevelUp", false, "",
+                            UIWidgets::CheckboxGraphics::Checkmark, true);
+        EnhancementCheckbox("Level Affects Magic Capacity", "gLeveledMagicWithLevelUp", false, "",
+                            UIWidgets::CheckboxGraphics::Checkmark, true);
+        EnhancementCheckbox("Enemy Level Affects Base Attack", "gLeveledEnemyAttackScalesWithLevel",
+                            false, "", UIWidgets::CheckboxGraphics::Checkmark, true);
+        UIWidgets::Tooltip("Enemies have a fixed attack value. This option scales this up the higher the enemy's "
+                            "Power(Strength) stat. \nThis will increase difficulty a bit.");
+        EnhancementCheckbox("Equipment Affects Stats", "gLeveledEquipmentStats", false, "",
+                            UIWidgets::CheckboxGraphics::Checkmark, true);
+        EnhancementCheckbox("Navi tells enemy level", "gLeveledNaviLevel", false, "",
+                            UIWidgets::CheckboxGraphics::Checkmark, true);
+        EnhancementCheckbox("Navi tells enemy max HP", "gLeveledNaviMaxHP", false, "",
+                            UIWidgets::CheckboxGraphics::Checkmark, true);
+
+        if (ImGui::BeginMenu("Heart Capacity in Units")) {
+            CVarGetInteger("gLeveledHeartUnits", 4);
+            UIWidgets::EnhancementRadioButton("4", "gLeveledHeartUnits", 1);
+            UIWidgets::EnhancementRadioButton("8", "gLeveledHeartUnits", 2);
+            UIWidgets::EnhancementRadioButton("12", "gLeveledHeartUnits", 3);
+            UIWidgets::EnhancementRadioButton("16 (Vanilla)", "gLeveledHeartUnits", 4);
+            UIWidgets::EnhancementRadioButton("20", "gLeveledHeartUnits", 5);
+            UIWidgets::EnhancementRadioButton("24", "gLeveledHeartUnits", 6);
+            UIWidgets::EnhancementRadioButton("28", "gLeveledHeartUnits", 7);
+            UIWidgets::EnhancementRadioButton("32", "gLeveledHeartUnits", 8);
+            UIWidgets::EnhancementRadioButton("36", "gLeveledHeartUnits", 9);
+            UIWidgets::EnhancementRadioButton("40", "gLeveledHeartUnits", 10);
+            UIWidgets::EnhancementRadioButton("44", "gLeveledHeartUnits", 11);
+            UIWidgets::EnhancementRadioButton("48", "gLeveledHeartUnits", 12);
+            ImGui::EndMenu();
+        }
+        UIWidgets::Tooltip("Sets how much health units a heart is worth.");
+
+        // if (ImGui::Button("Add 2000 EXP")){
+        //     gSaveContext.experience += 2000;
+        // }
+
+        ImGui::EndMenu();
+    }
+}
+
 void SohMenuBar::DrawElement() {
     if (ImGui::BeginMenuBar()) {
         DrawMenuBarIcon();
@@ -1477,58 +1530,11 @@ void SohMenuBar::DrawElement() {
 
         DrawRandomizerMenu();
 
+        ImGui::SetCursorPosY(0.0f);
+
+        DrawLeveledMenu();
+
         ImGui::PopStyleVar(1);
-
-        if (ImGui::BeginMenu("Leveled")) {
-            if (ImGui::BeginMenu("Floating Numbers")) {
-                EnhancementCheckbox("Enemy Damage", "gLeveledFloatingNumberEnemyDamage", false, "",
-                                    UIWidgets::CheckboxGraphics::Checkmark, true);
-                EnhancementCheckbox("Player Damage", "gLeveledFloatingNumberPlayerDamage", false, "",
-                                    UIWidgets::CheckboxGraphics::Checkmark, true);
-                EnhancementCheckbox("EXP Gain", "gLeveledFloatingNumberExpGain", false, "",
-                                    UIWidgets::CheckboxGraphics::Checkmark, true);
-                ImGui::EndMenu();
-            }
-
-            EnhancementCheckbox("Level Gives Bonus Hearts", "gLeveledHeartsWithLevelUp", false, "",
-                                UIWidgets::CheckboxGraphics::Checkmark, true);
-            EnhancementCheckbox("Level Affects Magic Capacity", "gLeveledMagicWithLevelUp", false, "",
-                                UIWidgets::CheckboxGraphics::Checkmark, true);
-            EnhancementCheckbox("Enemy Level Affects Base Attack", "gLeveledEnemyAttackScalesWithLevel",
-                                false, "", UIWidgets::CheckboxGraphics::Checkmark, true);
-            UIWidgets::Tooltip("Enemies have a fixed attack value. This option scales this up the higher the enemy's "
-                               "Power(Strength) stat. \nThis will increase difficulty a bit.");
-            EnhancementCheckbox("Equipment Affects Stats", "gLeveledEquipmentStats", false, "",
-                                UIWidgets::CheckboxGraphics::Checkmark, true);
-            EnhancementCheckbox("Navi tells enemy level", "gLeveledNaviLevel", false, "",
-                                UIWidgets::CheckboxGraphics::Checkmark, true);
-            EnhancementCheckbox("Navi tells enemy max HP", "gLeveledNaviMaxHP", false, "",
-                                UIWidgets::CheckboxGraphics::Checkmark, true);
-
-            if (ImGui::BeginMenu("Heart Capacity in Units")) {
-                CVarGetInteger("gLeveledHeartUnits", 4);
-                UIWidgets::EnhancementRadioButton("4", "gLeveledHeartUnits", 1);
-                UIWidgets::EnhancementRadioButton("8", "gLeveledHeartUnits", 2);
-                UIWidgets::EnhancementRadioButton("12", "gLeveledHeartUnits", 3);
-                UIWidgets::EnhancementRadioButton("16 (Vanilla)", "gLeveledHeartUnits", 4);
-                UIWidgets::EnhancementRadioButton("20", "gLeveledHeartUnits", 5);
-                UIWidgets::EnhancementRadioButton("24", "gLeveledHeartUnits", 6);
-                UIWidgets::EnhancementRadioButton("28", "gLeveledHeartUnits", 7);
-                UIWidgets::EnhancementRadioButton("32", "gLeveledHeartUnits", 8);
-                UIWidgets::EnhancementRadioButton("36", "gLeveledHeartUnits", 9);
-                UIWidgets::EnhancementRadioButton("40", "gLeveledHeartUnits", 10);
-                UIWidgets::EnhancementRadioButton("44", "gLeveledHeartUnits", 11);
-                UIWidgets::EnhancementRadioButton("48", "gLeveledHeartUnits", 12);
-                ImGui::EndMenu();
-            }
-            UIWidgets::Tooltip("Sets how much health units a heart is worth.");
-
-            // if (ImGui::Button("Add 2000 EXP")){
-            //     gSaveContext.experience += 2000;
-            // }
-
-            ImGui::EndMenu();
-        }
 
         ImGui::EndMenuBar();
     }


### PR DESCRIPTION
This moves the logic to draw the Leveled menu to its own method, following the same convention as all other menus in the file, resets the Y pos to 0 before drawing the menu, and waits to pop the window padding var until after the menu has been drawn.

This fixes the slight misalignment of the menu, as seen here:
![image](https://github.com/Arrenton/Shipwright/assets/13367296/e0ea0c3c-3176-45e9-ba6b-f98b32fb066b)
