### PR TITLE
Upgrade GitHub actions using deprecated Node version (#4371)

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -9,11 +9,11 @@ jobs:
   generate-soh-otr:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
+      uses: hendrikmuhs/ccache-action@v1.2.14
       with:
         key: ${{ runner.os }}-otr-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
@@ -73,11 +73,11 @@ jobs:
     needs: generate-soh-otr
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.13
+      uses: hendrikmuhs/ccache-action@v1.2.14
       with:
         create-symlink: true
         key: ${{ runner.os }}-14-ccache-${{ github.ref }}-${{ github.sha }}
@@ -91,7 +91,7 @@ jobs:
         sudo chmod +x /opt/homebrew/bin/gtar
     - name: Cache MacPorts
       id: cache-macports
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /opt/local/
         key: ${{ runner.os }}-14-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
@@ -135,7 +135,7 @@ jobs:
     needs: generate-soh-otr
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install dependencies
@@ -143,7 +143,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
+      uses: hendrikmuhs/ccache-action@v1.2.14
       with:
         key: linux-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
@@ -229,11 +229,11 @@ jobs:
       run: |
         choco install ninja
         Remove-Item -Path "C:\ProgramData\Chocolatey\bin\ccache.exe" -Force -ErrorAction SilentlyContinue
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
+      uses: hendrikmuhs/ccache-action@v1.2.14
       with:
         variant: sccache
         max-size: "1G"

--- a/.github/workflows/test-builds-on-distros.yml
+++ b/.github/workflows/test-builds-on-distros.yml
@@ -59,7 +59,7 @@ jobs:
         cmake ..
         make
         sudo make install
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Build SoH


### PR DESCRIPTION
* Upgrade Ccache action to v1.2.14

* Upgrade Ccache action to v1.2.14

* Upgrade GitHub checkout action to v4

* Upgrade another cache action